### PR TITLE
skip status hooks when CLUTCH_SESSION_ID is unset

### DIFF
--- a/src-tauri/src/hooks_config.rs
+++ b/src-tauri/src/hooks_config.rs
@@ -10,7 +10,7 @@ fn claude_settings_path() -> Option<PathBuf> {
 fn hook_command(event_name: &str) -> String {
     let base = config::base_dir_name();
     format!(
-        r#"f="$HOME/{base}/sessions/$CLUTCH_SESSION_ID/status"; t="$f.tmp.$$"; {{ echo "{event_name}"; cat "$f" 2>/dev/null; }} > "$t" && mv "$t" "$f""#
+        r#"[ -n "$CLUTCH_SESSION_ID" ] && {{ f="$HOME/{base}/sessions/$CLUTCH_SESSION_ID/status"; t="$f.tmp.$$"; {{ echo "{event_name}"; cat "$f" 2>/dev/null; }} > "$t" && mv "$t" "$f"; }}"#
     )
 }
 


### PR DESCRIPTION
Guard hook commands with [ -n "$CLUTCH_SESSION_ID" ] so they no-op when Claude Code runs outside of Clutch, preventing orphaned status.tmp files in the sessions directory.