### PR TITLE
use separate store file for dev and release builds

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,7 +3,7 @@ export const DEBUG_FORCE_ONBOARDING = false;
 export const DEBUG_FORCE_UPDATE_TOAST = false;
 
 // Persistence
-export const STORE_FILE = "sessions.json";
+export const STORE_FILE = import.meta.env.DEV ? "sessions-dev.json" : "sessions.json";
 
 // Polling intervals (ms)
 export const ACTIVITY_POLL_INTERVAL = 250;


### PR DESCRIPTION
Dev builds now write to sessions-dev.json while release builds use sessions.json, preventing session data from leaking across environments.