### PR TITLE
fix: use PowerShell as default shell on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tokio",
+ "which",
 ]
 
 [[package]]
@@ -824,6 +825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +876,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -5033,6 +5046,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,6 +5527,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.8"
 tokio = { version = "1", features = ["sync", "rt"] }
+which = "7"

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -287,8 +287,14 @@ impl PtyManager {
 /// Get the default shell for the current platform.
 #[cfg(windows)]
 fn get_default_shell() -> String {
-    // On Windows, prefer PowerShell, fall back to cmd.exe
-    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    // On Windows, prefer PowerShell 7+ (pwsh), then Windows PowerShell (powershell), fall back to cmd.exe
+    if which::which("pwsh").is_ok() {
+        "pwsh.exe".to_string()
+    } else if which::which("powershell").is_ok() {
+        "powershell.exe".to_string()
+    } else {
+        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    }
 }
 
 #[cfg(not(windows))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clutch",
-  "version": "26.211.0",
+  "version": "26.211.1",
   "identifier": "computer.clutch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Previously the Windows shell defaulted to cmd.exe (via COMSPEC).
Now it prefers PowerShell 7+ (pwsh.exe), falls back to Windows
PowerShell (powershell.exe), and only uses cmd.exe if neither
is available. This provides a better Unix-like experience with
commands like ls, ps, and proper shell variable expansion.

Fixes #32

Generated with [Claude Code](https://claude.ai/code)